### PR TITLE
add helper methods to manipulate Statistics

### DIFF
--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -76,6 +76,4 @@ public interface Model {
     void setPomodoroTask(Task task);
 
     ReadOnlyStatistics getStatistics();
-
-    void setStatistics(String data); // placeholder
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -201,8 +201,8 @@ public class ModelManager implements Model {
         return statistics;
     }
 
-    public void fetchStatistics() {
-        statistics.fetch();
+    public void updateDataDatesStatistics() {
+        statistics.updateDataDates();
     }
 
     public void updatesDayDataStatistics(DayData dayData) {
@@ -212,6 +212,4 @@ public class ModelManager implements Model {
     public DayData getDayDataFromDate(Date date) {
         return statistics.getDayDataFromDate(date);
     }
-
-
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -212,6 +212,4 @@ public class ModelManager implements Model {
     public DayData getDayDataFromDate(Date date) {
         return statistics.getDayDataFromDate(date);
     }
-
-
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -10,6 +10,8 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.dayData.Date;
+import seedu.address.model.dayData.DayData;
 import seedu.address.model.task.Task;
 
 /** Represents the in-memory model of the address book data. */
@@ -161,7 +163,8 @@ public class ModelManager implements Model {
                 && filteredTasks.equals(other.filteredTasks);
     }
 
-    // TODO Add a manager for pets
+    // ============================ Pet Manager
+
     @Override
     public ReadOnlyPet getPet() {
         return pet;
@@ -177,29 +180,38 @@ public class ModelManager implements Model {
         this.pet.incrementPomExp();
     }
 
-    public ReadOnlyPomodoro getPomodoro() {
-        return pomodoro;
-    }
-
-    // TODO add a manager for statistics
-    public ReadOnlyStatistics getStatistics() {
-        return statistics;
-    }
-
-    // ============================ Pomodoro Manager
-
-    public void setPomodoroTask(Task task) {
-        this.pomodoro.setTask(task);
-    }
-
     @Override
     public void incrementExp() {
         this.pet.incrementExp();
     }
 
+    // ============================ Pomodoro Manager
+
+    public ReadOnlyPomodoro getPomodoro() {
+        return pomodoro;
+    }
+
+    public void setPomodoroTask(Task task) {
+        this.pomodoro.setTask(task);
+    }
+
     // ============================ Statistics Manager
 
-    public void setStatistics(String data) {
-        // placeholder
+    public ReadOnlyStatistics getStatistics() {
+        return statistics;
     }
+
+    public void fetchStatistics() {
+        statistics.fetch();
+    }
+
+    public void updatesDayDataStatistics(DayData dayData) {
+        statistics.updatesDayData(dayData);
+    }
+
+    public DayData getDayDataFromDate(Date date) {
+        return statistics.getDayDataFromDate(date);
+    }
+
+
 }

--- a/src/main/java/seedu/address/model/Statistics.java
+++ b/src/main/java/seedu/address/model/Statistics.java
@@ -6,15 +6,12 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-
 import seedu.address.model.dayData.Date;
 import seedu.address.model.dayData.DayData;
 import seedu.address.model.dayData.PomDurationData;
 import seedu.address.model.dayData.TasksDoneData;
 
-/**
- * Wraps all DayData objects.
- */
+/** Wraps all DayData objects. */
 public class Statistics implements ReadOnlyStatistics {
 
     private final ArrayList<DayData> dayDataList;
@@ -36,7 +33,8 @@ public class Statistics implements ReadOnlyStatistics {
         LocalDate currDate = LocalDate.now();
         for (int i = 0; i < MAX_SIZE; i++) {
             LocalDate tempLocalDate = currDate.minusDays(i);
-            Date tempDate = new Date(tempLocalDate);
+            String tempLocalDateStr = tempLocalDate.toString();
+            Date tempDate = new Date(tempLocalDateStr);
             DayData dayData = new DayData(tempDate);
             dayDataList.add(dayData);
         }
@@ -49,9 +47,7 @@ public class Statistics implements ReadOnlyStatistics {
         this.dayDataList.clear();
     }
 
-    /**
-     * Replaces the contents of the list with {@code dayDataList}.
-     */
+    /** Replaces the contents of the list with {@code dayDataList}. */
     public void setDayDatas(List<DayData> dayDataList) {
         this.dayDataList.clear();
         this.dayDataList.addAll(dayDataList);
@@ -65,16 +61,19 @@ public class Statistics implements ReadOnlyStatistics {
 
     //// dayData-level operations
 
-    // FUNCTIONS FOR HARDOHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH SIR
+    // FUNCTIONS FOR
+    // HARDOHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH SIR
 
     /** reinitialises dayDataList to current day while retaining stored data. */
-    public void fetch() {
+    public void updateDataDates() {
         HashMap<Date, PomDurationData> pomTempStorage = new HashMap<>();
         HashMap<Date, TasksDoneData> tasksTempStorage = new HashMap<>();
 
         for (int i = 0; i < dayDataList.size(); i++) {
-            pomTempStorage.put(dayDataList.get(i).getDate(), dayDataList.get(i).getPomDurationData());
-            tasksTempStorage.put(dayDataList.get(i).getDate(), dayDataList.get(i).getTasksDoneData());
+            pomTempStorage.put(
+                    dayDataList.get(i).getDate(), dayDataList.get(i).getPomDurationData());
+            tasksTempStorage.put(
+                    dayDataList.get(i).getDate(), dayDataList.get(i).getTasksDoneData());
         }
 
         this.init();
@@ -84,20 +83,21 @@ public class Statistics implements ReadOnlyStatistics {
             if (pomTempStorage.containsKey(currTempDate)) {
                 PomDurationData tempPomDurationDate = pomTempStorage.get(currTempDate);
                 TasksDoneData tempTasksDoneData = tasksTempStorage.get(currTempDate);
-                DayData tempDayData = new DayData(currTempDate, tempPomDurationDate, tempTasksDoneData);
+                DayData tempDayData =
+                        new DayData(currTempDate, tempPomDurationDate, tempTasksDoneData);
                 dayDataList.remove(i);
                 dayDataList.add(i, tempDayData);
             }
         }
 
-        assert(dayDataList.size() <= MAX_SIZE);
-
+        assert (dayDataList.size() <= MAX_SIZE);
     }
 
     /**
      * Auto-checks and replaces a new DayData object at the same Date
+     *
      * @param dayData
-    */
+     */
     public void updatesDayData(DayData dayData) {
         requireNonNull(dayData);
 
@@ -111,8 +111,7 @@ public class Statistics implements ReadOnlyStatistics {
                 return;
             }
         }
-        assert(false); // dayData not found
-
+        assert (false); // dayData not found
     }
 
     /**
@@ -136,9 +135,7 @@ public class Statistics implements ReadOnlyStatistics {
 
     // FUNCTIONS FOR HARDOHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH end
 
-    /**
-     * Returns true if a dayData with the same identity as {@code dayData} exists in the list.
-     */
+    /** Returns true if a dayData with the same identity as {@code dayData} exists in the list. */
     public boolean hasDayData(DayData dayData) {
         requireNonNull(dayData);
         return dayDataList.contains(dayData);

--- a/src/main/java/seedu/address/model/Statistics.java
+++ b/src/main/java/seedu/address/model/Statistics.java
@@ -6,15 +6,12 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-
 import seedu.address.model.dayData.Date;
 import seedu.address.model.dayData.DayData;
 import seedu.address.model.dayData.PomDurationData;
 import seedu.address.model.dayData.TasksDoneData;
 
-/**
- * Wraps all DayData objects.
- */
+/** Wraps all DayData objects. */
 public class Statistics implements ReadOnlyStatistics {
 
     private final ArrayList<DayData> dayDataList;
@@ -36,7 +33,8 @@ public class Statistics implements ReadOnlyStatistics {
         LocalDate currDate = LocalDate.now();
         for (int i = 0; i < MAX_SIZE; i++) {
             LocalDate tempLocalDate = currDate.minusDays(i);
-            Date tempDate = new Date(tempLocalDate);
+            String tempLocalDateStr = tempLocalDate.toString();
+            Date tempDate = new Date(tempLocalDateStr);
             DayData dayData = new DayData(tempDate);
             dayDataList.add(dayData);
         }
@@ -49,9 +47,7 @@ public class Statistics implements ReadOnlyStatistics {
         this.dayDataList.clear();
     }
 
-    /**
-     * Replaces the contents of the list with {@code dayDataList}.
-     */
+    /** Replaces the contents of the list with {@code dayDataList}. */
     public void setDayDatas(List<DayData> dayDataList) {
         this.dayDataList.clear();
         this.dayDataList.addAll(dayDataList);
@@ -65,7 +61,8 @@ public class Statistics implements ReadOnlyStatistics {
 
     //// dayData-level operations
 
-    // FUNCTIONS FOR HARDOHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH SIR
+    // FUNCTIONS FOR
+    // HARDOHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH SIR
 
     /** reinitialises dayDataList to current day while retaining stored data. */
     public void fetch() {
@@ -73,8 +70,10 @@ public class Statistics implements ReadOnlyStatistics {
         HashMap<Date, TasksDoneData> tasksTempStorage = new HashMap<>();
 
         for (int i = 0; i < dayDataList.size(); i++) {
-            pomTempStorage.put(dayDataList.get(i).getDate(), dayDataList.get(i).getPomDurationData());
-            tasksTempStorage.put(dayDataList.get(i).getDate(), dayDataList.get(i).getTasksDoneData());
+            pomTempStorage.put(
+                    dayDataList.get(i).getDate(), dayDataList.get(i).getPomDurationData());
+            tasksTempStorage.put(
+                    dayDataList.get(i).getDate(), dayDataList.get(i).getTasksDoneData());
         }
 
         this.init();
@@ -84,20 +83,21 @@ public class Statistics implements ReadOnlyStatistics {
             if (pomTempStorage.containsKey(currTempDate)) {
                 PomDurationData tempPomDurationDate = pomTempStorage.get(currTempDate);
                 TasksDoneData tempTasksDoneData = tasksTempStorage.get(currTempDate);
-                DayData tempDayData = new DayData(currTempDate, tempPomDurationDate, tempTasksDoneData);
+                DayData tempDayData =
+                        new DayData(currTempDate, tempPomDurationDate, tempTasksDoneData);
                 dayDataList.remove(i);
                 dayDataList.add(i, tempDayData);
             }
         }
 
-        assert(dayDataList.size() <= MAX_SIZE);
-
+        assert (dayDataList.size() <= MAX_SIZE);
     }
 
     /**
      * Auto-checks and replaces a new DayData object at the same Date
+     *
      * @param dayData
-    */
+     */
     public void updatesDayData(DayData dayData) {
         requireNonNull(dayData);
 
@@ -111,8 +111,7 @@ public class Statistics implements ReadOnlyStatistics {
                 return;
             }
         }
-        assert(false); // dayData not found
-
+        assert (false); // dayData not found
     }
 
     /**
@@ -136,9 +135,7 @@ public class Statistics implements ReadOnlyStatistics {
 
     // FUNCTIONS FOR HARDOHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH end
 
-    /**
-     * Returns true if a dayData with the same identity as {@code dayData} exists in the list.
-     */
+    /** Returns true if a dayData with the same identity as {@code dayData} exists in the list. */
     public boolean hasDayData(DayData dayData) {
         requireNonNull(dayData);
         return dayDataList.contains(dayData);

--- a/src/main/java/seedu/address/model/Statistics.java
+++ b/src/main/java/seedu/address/model/Statistics.java
@@ -2,19 +2,27 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+
+import seedu.address.model.dayData.Date;
 import seedu.address.model.dayData.DayData;
+import seedu.address.model.dayData.PomDurationData;
+import seedu.address.model.dayData.TasksDoneData;
 
 /**
- * Wraps all data at the address-book level Duplicates are not allowed (by .isSameTask comparison)
+ * Wraps all DayData objects.
  */
 public class Statistics implements ReadOnlyStatistics {
 
     private final ArrayList<DayData> dayDataList;
+    private final int MAX_SIZE = 7;
 
     public Statistics() {
         dayDataList = new ArrayList<>();
+        this.init();
     }
 
     /** Creates an DayDataList using the DayDatas in the {@code toBeCopied} */
@@ -23,33 +31,120 @@ public class Statistics implements ReadOnlyStatistics {
         resetData(toBeCopied);
     }
 
+    /** Initialises empty DayData for past MAX_SIZE days */
+    public void init() {
+        LocalDate currDate = LocalDate.now();
+        for (int i = 0; i < MAX_SIZE; i++) {
+            LocalDate tempLocalDate = currDate.minusDays(i);
+            Date tempDate = new Date(tempLocalDate);
+            DayData dayData = new DayData(tempDate);
+            dayDataList.add(dayData);
+        }
+    }
+
     //// list overwrite operations
+
+    /** Clears list */
+    public void clearList() {
+        this.dayDataList.clear();
+    }
+
     /**
-     * Replaces the contents of the person list with {@code persons}. {@code persons} must not
-     * contain duplicate persons.
+     * Replaces the contents of the list with {@code dayDataList}.
      */
     public void setDayDatas(List<DayData> dayDataList) {
         this.dayDataList.clear();
         this.dayDataList.addAll(dayDataList);
     }
 
-    /** Resets the existing data of this {@code TaskList} with {@code newData}. */
+    /** Resets the existing data of this {@code Statistics} with {@code newData}. */
     public void resetData(ReadOnlyStatistics newData) {
         requireNonNull(newData);
         setDayDatas(newData.getDayDataList());
     }
 
-    //// person-level operations
+    //// dayData-level operations
+
+    // FUNCTIONS FOR HARDOHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH SIR
+
+    /** reinitialises dayDataList to current day while retaining stored data. */
+    public void fetch() {
+        HashMap<Date, PomDurationData> pomTempStorage = new HashMap<>();
+        HashMap<Date, TasksDoneData> tasksTempStorage = new HashMap<>();
+
+        for (int i = 0; i < dayDataList.size(); i++) {
+            pomTempStorage.put(dayDataList.get(i).getDate(), dayDataList.get(i).getPomDurationData());
+            tasksTempStorage.put(dayDataList.get(i).getDate(), dayDataList.get(i).getTasksDoneData());
+        }
+
+        this.init();
+
+        for (int i = 0; i < dayDataList.size(); i++) { // updated dayDatalist
+            Date currTempDate = dayDataList.get(i).getDate();
+            if (pomTempStorage.containsKey(currTempDate)) {
+                PomDurationData tempPomDurationDate = pomTempStorage.get(currTempDate);
+                TasksDoneData tempTasksDoneData = tasksTempStorage.get(currTempDate);
+                DayData tempDayData = new DayData(currTempDate, tempPomDurationDate, tempTasksDoneData);
+                dayDataList.remove(i);
+                dayDataList.add(i, tempDayData);
+            }
+        }
+
+        assert(dayDataList.size() <= MAX_SIZE);
+
+    }
 
     /**
-     * Returns true if a person with the same identity as {@code person} exists in the address book.
+     * Auto-checks and replaces a new DayData object at the same Date
+     * @param dayData
+    */
+    public void updatesDayData(DayData dayData) {
+        requireNonNull(dayData);
+
+        Date currDate = dayData.getDate();
+        for (int i = 0; i < dayDataList.size(); i++) {
+            DayData currDayData = dayDataList.get(i);
+            Date currDayDataDate = currDayData.getDate();
+            if (currDayDataDate.equals(currDate)) { // correct date
+                dayDataList.remove(i);
+                dayDataList.add(i, dayData);
+                return;
+            }
+        }
+        assert(false); // dayData not found
+
+    }
+
+    /**
+     * Gets DayData object at current date.
+     *
+     * @param date
      */
-    public boolean hasTask(DayData dayData) {
+    public DayData getDayDataFromDate(Date date) {
+        requireNonNull(date);
+
+        for (int i = 0; i < dayDataList.size(); i++) {
+            DayData currDayData = dayDataList.get(i);
+            Date currDayDataDate = currDayData.getDate();
+            if (currDayDataDate.equals(date)) {
+                return currDayData;
+            }
+        }
+
+        return null;
+    }
+
+    // FUNCTIONS FOR HARDOHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH end
+
+    /**
+     * Returns true if a dayData with the same identity as {@code dayData} exists in the list.
+     */
+    public boolean hasDayData(DayData dayData) {
         requireNonNull(dayData);
         return dayDataList.contains(dayData);
     }
 
-    /** Adds a person to the address book. The person must not already exist in the address book. */
+    /** Adds a dayData to the list. The person must not already exist in the address book. */
     public void addDayData(DayData dayData) {
         dayDataList.add(dayData);
     }

--- a/src/main/java/seedu/address/model/dayData/Date.java
+++ b/src/main/java/seedu/address/model/dayData/Date.java
@@ -3,6 +3,7 @@ package seedu.address.model.dayData;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
@@ -18,16 +19,16 @@ public class Date {
     public static final DateTimeFormatter dateFormatter =
             DateTimeFormatter.ofPattern("uuuu-MM-dd", Locale.US)
                     .withResolverStyle(ResolverStyle.STRICT);
-    public final String value;
+    public final LocalDate value;
 
     /**
      * Constructs a {@code Date}.
      *
      * @param date A valid priority number.
      */
-    public Date(String date) {
+    public Date(LocalDate date) {
         requireNonNull(date);
-        checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidDate(date.toString()), MESSAGE_CONSTRAINTS);
         value = date;
     }
 
@@ -43,7 +44,7 @@ public class Date {
 
     @Override
     public String toString() {
-        return value;
+        return value.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/dayData/Date.java
+++ b/src/main/java/seedu/address/model/dayData/Date.java
@@ -26,10 +26,11 @@ public class Date {
      *
      * @param date A valid priority number.
      */
-    public Date(LocalDate date) {
+    public Date(String date) {
         requireNonNull(date);
-        checkArgument(isValidDate(date.toString()), MESSAGE_CONSTRAINTS);
-        value = date;
+        checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
+        LocalDate localDate = LocalDate.parse(date);
+        value = localDate;
     }
 
     /** Returns true if a given string is a valid date. */

--- a/src/main/java/seedu/address/model/dayData/DayData.java
+++ b/src/main/java/seedu/address/model/dayData/DayData.java
@@ -12,6 +12,12 @@ public class DayData {
         this.tasksDoneData = tasksDoneData;
     }
 
+    public DayData(Date date) {
+        this.date = date;
+        this.pomDurationData = new PomDurationData();
+        this.tasksDoneData = new TasksDoneData();
+    }
+
     public Date getDate() {
         return this.date;
     }

--- a/src/main/java/seedu/address/model/dayData/PomDurationData.java
+++ b/src/main/java/seedu/address/model/dayData/PomDurationData.java
@@ -13,6 +13,11 @@ public class PomDurationData {
             "PomDurationData is an integer greater than or equals to 0 and less than 1440";
     public final String value;
 
+    /** Constructs a {@code PomDurationData}. */
+    public PomDurationData() {
+        value = "0";
+    }
+
     /**
      * Constructs a {@code PomDurationData}.
      *

--- a/src/main/java/seedu/address/model/dayData/PomDurationData.java
+++ b/src/main/java/seedu/address/model/dayData/PomDurationData.java
@@ -11,11 +11,11 @@ public class PomDurationData {
 
     public static final String MESSAGE_CONSTRAINTS =
             "PomDurationData is an integer greater than or equals to 0 and less than 1440";
-    public final String value;
+    public final Integer value;
 
     /** Constructs a {@code PomDurationData}. */
     public PomDurationData() {
-        value = "0";
+        value = 0;
     }
 
     /**
@@ -26,7 +26,7 @@ public class PomDurationData {
     public PomDurationData(String pomDurationData) {
         requireNonNull(pomDurationData);
         checkArgument(isValidPomDurationData(pomDurationData), MESSAGE_CONSTRAINTS);
-        value = pomDurationData;
+        value = Integer.valueOf(pomDurationData);
     }
 
     /** Returns true if a given string is a valid priority number. */
@@ -41,7 +41,7 @@ public class PomDurationData {
 
     @Override
     public String toString() {
-        return value;
+        return value.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/dayData/TasksDoneData.java
+++ b/src/main/java/seedu/address/model/dayData/TasksDoneData.java
@@ -11,11 +11,11 @@ public class TasksDoneData {
 
     public static final String MESSAGE_CONSTRAINTS =
             "TasksDoneData is an integer greater than or equals to 0";
-    public final String value;
+    public final Integer value;
 
     /** Constructs a {@code TasksDoneData}. */
     public TasksDoneData() {
-        value = "0";
+        value = 0;
     }
 
     /**
@@ -26,7 +26,7 @@ public class TasksDoneData {
     public TasksDoneData(String taskDoneData) {
         requireNonNull(taskDoneData);
         checkArgument(isValidTasksDoneData(taskDoneData), MESSAGE_CONSTRAINTS);
-        value = taskDoneData;
+        value = Integer.valueOf(taskDoneData);
     }
 
     /** Returns true if a given string is a valid priority number. */
@@ -41,7 +41,7 @@ public class TasksDoneData {
 
     @Override
     public String toString() {
-        return value;
+        return value.toString();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/dayData/TasksDoneData.java
+++ b/src/main/java/seedu/address/model/dayData/TasksDoneData.java
@@ -13,6 +13,11 @@ public class TasksDoneData {
             "TasksDoneData is an integer greater than or equals to 0";
     public final String value;
 
+    /** Constructs a {@code TasksDoneData}. */
+    public TasksDoneData() {
+        value = "0";
+    }
+
     /**
      * Constructs a {@code TasksDoneData}.
      *

--- a/src/main/java/seedu/address/storage/JsonAdaptedDayData.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedDayData.java
@@ -8,6 +8,8 @@ import seedu.address.model.dayData.DayData;
 import seedu.address.model.dayData.PomDurationData;
 import seedu.address.model.dayData.TasksDoneData;
 
+import java.time.LocalDate;
+
 /** Jackson-friendly version of {@link DayData}. */
 class JsonAdaptedDayData {
 
@@ -30,7 +32,7 @@ class JsonAdaptedDayData {
 
     /** Converts a given {@code Task} into this class for Jackson use. */
     public JsonAdaptedDayData(DayData source) {
-        date = source.getDate().value;
+        date = source.getDate().toString();
         pomDurationData = source.getPomDurationData().value;
         tasksDoneData = source.getTasksDoneData().value;
     }
@@ -46,10 +48,12 @@ class JsonAdaptedDayData {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName()));
         }
+
         if (!Date.isValidDate(date)) {
             throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
         }
-        final Date modelDate = new Date(date);
+        LocalDate localDate = LocalDate.parse(date);
+        final Date modelDate = new Date(localDate);
 
         if (pomDurationData == null) {
             throw new IllegalValueException(

--- a/src/main/java/seedu/address/storage/JsonAdaptedDayData.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedDayData.java
@@ -2,13 +2,12 @@ package seedu.address.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.dayData.Date;
 import seedu.address.model.dayData.DayData;
 import seedu.address.model.dayData.PomDurationData;
 import seedu.address.model.dayData.TasksDoneData;
-
-import java.time.LocalDate;
 
 /** Jackson-friendly version of {@link DayData}. */
 class JsonAdaptedDayData {
@@ -33,8 +32,8 @@ class JsonAdaptedDayData {
     /** Converts a given {@code Task} into this class for Jackson use. */
     public JsonAdaptedDayData(DayData source) {
         date = source.getDate().toString();
-        pomDurationData = source.getPomDurationData().value;
-        tasksDoneData = source.getTasksDoneData().value;
+        pomDurationData = source.getPomDurationData().toString();
+        tasksDoneData = source.getTasksDoneData().toString();
     }
 
     /**
@@ -52,8 +51,7 @@ class JsonAdaptedDayData {
         if (!Date.isValidDate(date)) {
             throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
         }
-        LocalDate localDate = LocalDate.parse(date);
-        final Date modelDate = new Date(localDate);
+        final Date modelDate = new Date(date);
 
         if (pomDurationData == null) {
             throw new IllegalValueException(

--- a/src/main/java/seedu/address/storage/JsonSerializableDayDataList.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableDayDataList.java
@@ -45,7 +45,7 @@ class JsonSerializableDayDataList {
      */
     public Statistics toModelType() throws IllegalValueException {
         Statistics dayDataList = new Statistics();
-        dayDataList.clearList(); //workaround to create empty list
+        dayDataList.clearList(); // workaround to create empty list
         for (JsonAdaptedDayData jsonAdaptedDayData : dayDatas) {
             DayData dayData = jsonAdaptedDayData.toModelType();
             dayDataList.addDayData(dayData);

--- a/src/main/java/seedu/address/storage/JsonSerializableDayDataList.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableDayDataList.java
@@ -45,6 +45,7 @@ class JsonSerializableDayDataList {
      */
     public Statistics toModelType() throws IllegalValueException {
         Statistics dayDataList = new Statistics();
+        dayDataList.clearList(); //workaround to create empty list
         for (JsonAdaptedDayData jsonAdaptedDayData : dayDatas) {
             DayData dayData = jsonAdaptedDayData.toModelType();
             dayDataList.addDayData(dayData);

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -22,7 +22,13 @@ public class AddCommandIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        model = new ModelManager(getTypicalTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+        model =
+                new ModelManager(
+                        getTypicalTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
     }
 
     @Test
@@ -30,7 +36,12 @@ public class AddCommandIntegrationTest {
         Task validTask = new TaskBuilder().build();
 
         Model expectedModel =
-                new ModelManager(model.getTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+                new ModelManager(
+                        model.getTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
         expectedModel.addTask(validTask);
 
         assertCommandSuccess(

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -187,11 +187,6 @@ public class AddCommandTest {
         public ReadOnlyStatistics getStatistics() {
             throw new AssertionError("This method should not be called.");
         }
-
-        @Override
-        public void setStatistics(String temp) {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /** A Model stub that contains a single person. */

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -20,7 +20,6 @@ import seedu.address.model.ReadOnlyPomodoro;
 import seedu.address.model.ReadOnlyStatistics;
 import seedu.address.model.ReadOnlyTaskList;
 import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.Statistics;
 import seedu.address.model.TaskList;
 import seedu.address.model.task.Task;
 import seedu.address.testutil.TaskBuilder;

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -26,9 +26,19 @@ public class ClearCommandTest {
     @Test
     public void execute_nonEmptyTaskList_success() {
         Model model =
-                new ModelManager(getTypicalTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+                new ModelManager(
+                        getTypicalTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
         Model expectedModel =
-                new ModelManager(getTypicalTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+                new ModelManager(
+                        getTypicalTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
         expectedModel.setTaskList(new TaskList());
 
         assertCommandSuccess(

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -27,7 +27,12 @@ import seedu.address.model.task.Task;
 public class DeleteCommandTest {
 
     private Model model =
-            new ModelManager(getTypicalTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+            new ModelManager(
+                    getTypicalTaskList(),
+                    new Pet(),
+                    new Pomodoro(),
+                    new Statistics(),
+                    new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -39,7 +44,12 @@ public class DeleteCommandTest {
         expectedMessage.append(String.format("%n%s", taskToDelete));
 
         ModelManager expectedModel =
-                new ModelManager(model.getTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+                new ModelManager(
+                        model.getTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
         expectedModel.deleteTask(taskToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage.toString(), expectedModel);
@@ -65,7 +75,12 @@ public class DeleteCommandTest {
         expectedMessage.append(String.format("%n%s", taskToDelete));
 
         Model expectedModel =
-                new ModelManager(model.getTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+                new ModelManager(
+                        model.getTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
         expectedModel.deleteTask(taskToDelete);
         showNoPerson(expectedModel);
 

--- a/src/test/java/seedu/address/logic/commands/DoneCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DoneCommandTest.java
@@ -29,7 +29,12 @@ import seedu.address.testutil.TaskBuilder;
 public class DoneCommandTest {
 
     private Model model =
-            new ModelManager(getTypicalTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+            new ModelManager(
+                    getTypicalTaskList(),
+                    new Pet(),
+                    new Pomodoro(),
+                    new Statistics(),
+                    new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -42,7 +47,12 @@ public class DoneCommandTest {
         expectedMessage.append(String.format("%n%s", doneTask));
 
         ModelManager expectedModel =
-                new ModelManager(model.getTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+                new ModelManager(
+                        model.getTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
         expectedModel.setTask(
                 model.getFilteredTaskList().get(INDEX_FIRST_PERSON.getZeroBased()), doneTask);
 
@@ -70,7 +80,12 @@ public class DoneCommandTest {
         expectedMessage.append(String.format("%n%s", doneTask));
 
         ModelManager expectedModel =
-                new ModelManager(model.getTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+                new ModelManager(
+                        model.getTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
         expectedModel.setTask(
                 model.getFilteredTaskList().get(INDEX_FIRST_PERSON.getZeroBased()), doneTask);
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -36,7 +36,12 @@ import seedu.address.testutil.TaskBuilder;
 public class EditCommandTest {
 
     private Model model =
-            new ModelManager(getTypicalTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+            new ModelManager(
+                    getTypicalTaskList(),
+                    new Pet(),
+                    new Pomodoro(),
+                    new Statistics(),
+                    new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -24,9 +24,19 @@ import seedu.address.model.task.NameContainsKeywordsPredicate;
 /** Contains integration tests (interaction with the Model) for {@code FindCommand}. */
 public class FindCommandTest {
     private Model model =
-            new ModelManager(getTypicalTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+            new ModelManager(
+                    getTypicalTaskList(),
+                    new Pet(),
+                    new Pomodoro(),
+                    new Statistics(),
+                    new UserPrefs());
     private Model expectedModel =
-            new ModelManager(getTypicalTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+            new ModelManager(
+                    getTypicalTaskList(),
+                    new Pet(),
+                    new Pomodoro(),
+                    new Statistics(),
+                    new UserPrefs());
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -30,7 +30,12 @@ public class ListCommandTest {
                         new Statistics(),
                         new UserPrefs()); // Should we shift these to ModelManager
         expectedModel =
-                new ModelManager(model.getTaskList(), new Pet(), new Pomodoro(), new Statistics(), new UserPrefs());
+                new ModelManager(
+                        model.getTaskList(),
+                        new Pet(),
+                        new Pomodoro(),
+                        new Statistics(),
+                        new UserPrefs());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -100,7 +100,8 @@ public class ModelManagerTest {
         UserPrefs userPrefs = new UserPrefs();
 
         // same values -> returns true
-        modelManager = new ModelManager(taskList, new Pet(), new Pomodoro(), new Statistics(), userPrefs);
+        modelManager =
+                new ModelManager(taskList, new Pet(), new Pomodoro(), new Statistics(), userPrefs);
         ModelManager modelManagerCopy =
                 new ModelManager(taskList, new Pet(), new Pomodoro(), new Statistics(), userPrefs);
         assertTrue(modelManager.equals(modelManagerCopy));
@@ -117,7 +118,12 @@ public class ModelManagerTest {
         // different taskList -> returns false
         assertFalse(
                 modelManager.equals(
-                        new ModelManager(differentTaskList, new Pet(), new Pomodoro(), new Statistics(), userPrefs)));
+                        new ModelManager(
+                                differentTaskList,
+                                new Pet(),
+                                new Pomodoro(),
+                                new Statistics(),
+                                userPrefs)));
 
         // different filteredList -> returns false
         String[] keywords = HOMEWORK10.getName().fullName.split("\\s+");
@@ -125,7 +131,8 @@ public class ModelManagerTest {
                 new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(
                 modelManager.equals(
-                        new ModelManager(taskList, new Pet(), new Pomodoro(), new Statistics(), userPrefs)));
+                        new ModelManager(
+                                taskList, new Pet(), new Pomodoro(), new Statistics(), userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredTaskList(PREDICATE_SHOW_ALL_PERSONS);
@@ -135,6 +142,11 @@ public class ModelManagerTest {
         differentUserPrefs.setTaskListFilePath(Paths.get("differentFilePath"));
         assertFalse(
                 modelManager.equals(
-                        new ModelManager(taskList, new Pet(), new Pomodoro(), new Statistics(), differentUserPrefs)));
+                        new ModelManager(
+                                taskList,
+                                new Pet(),
+                                new Pomodoro(),
+                                new Statistics(),
+                                differentUserPrefs)));
     }
 }

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -30,7 +30,12 @@ public class StorageManagerTest {
         JsonPetStorage petStorage = new JsonPetStorage(getTempFilePath("pet.json"));
 
         storageManager =
-                new StorageManager(taskListStorage, petStorage, pomodoroStorage, statisticsStorage, userPrefsStorage);
+                new StorageManager(
+                        taskListStorage,
+                        petStorage,
+                        pomodoroStorage,
+                        statisticsStorage,
+                        userPrefsStorage);
     }
 
     private Path getTempFilePath(String fileName) {


### PR DESCRIPTION
CS2103T Individual Assignment for Sir Hardoh

**Problem statement:** We want to keep track of data in the past n (7) days while accounting for usage across different days. (eg. Use 1 day, never touch for 2 days, or 10 days, and use again)

**Tentative solution:** statistics.json will store and track the DayData (Date [LocalDate], PomDurationData [Integer], TasksDoneData [Integer]) for the past n days. Note that you construct Date, PomDurationData and TasksDoneData using Strings.

Statistics will create a list of empty DayData objects for the past 7 days (including current day) upon initialisation in statistics.json. I have defined several helper methods in Statistics for your usage. 
```
fetch() // reinitialises dayDataList to current day while retaining stored data.
updatesDayData(DayData dayData) // Auto-checks and replaces a new DayData object at the same Date
getDayDataFromDate(Date date) // Gets DayData object at current date.

```

**Proposed Implementation:**

Check if current date exist in list using getDayDataFromDate.

LEVEL 1
If date exist, simply add data to the DayData obtained.
Then update the list using updatesDayData.

LEVEL 2
If date doesn't exist, this means list is outdated, and should be reinitialised using fetch to update list to the new day, which also deletes the outdated days in the list.
Repeat LEVEL 1 for new day.
If this is the event where day crosses to the next day, remember to repeat LEVEL 1 for the previous day too.
 
Please feel free to propose/make any changes to this implementation.