### PR TITLE
Feature/update display on recurr

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -109,9 +109,9 @@ public class MainApp extends Application {
 
         model.setStatisticsManager(statisticsManager);
 
-        model.addObserver(logic);
-
         ui = new UiManager(logic, pomodoroManager, petManager, statisticsManager);
+
+        model.addObserver(ui);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -12,7 +12,7 @@ import seedu.address.model.dayData.DayData;
 import seedu.address.model.task.Task;
 
 /** API of the Logic component */
-public interface Logic extends Observer {
+public interface Logic {
     /**
      * Executes the command and returns the result.
      *

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -8,7 +8,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyPomodoro;
 import seedu.address.model.ReadOnlyTaskList;
-import seedu.address.model.dayData.DayData;
 import seedu.address.model.task.Task;
 
 /** API of the Logic component */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -15,7 +15,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyPomodoro;
 import seedu.address.model.ReadOnlyTaskList;
 import seedu.address.model.TaskList;
-import seedu.address.model.dayData.DayData;
 import seedu.address.model.task.Task;
 import seedu.address.storage.Storage;
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -85,10 +85,6 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Task> getFilteredTaskList() {
         ObservableList<Task> tasklist = model.getFilteredTaskList();
-        // for (int i = 0; i < tasklist.size(); i++) {
-        //     Task currentTask = tasklist.get(i);
-        //     currentTask.triggerRecurringIfPresent(model, Index.fromZeroBased(i));
-        // }
         return tasklist;
     }
 
@@ -117,12 +113,12 @@ public class LogicManager implements Logic {
         return model.getPomodoro();
     }
 
-    @Override
-    public void update() throws CommandException {
-        try {
-            storage.saveTaskList(model.getTaskList());
-        } catch (IOException ioe) {
-            throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
-        }
-    }
+    // @Override
+    // public void update() throws CommandException {
+    //     try {
+    //         storage.saveTaskList(model.getTaskList());
+    //     } catch (IOException ioe) {
+    //         throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
+    //     }
+    // }
 }

--- a/src/main/java/seedu/address/logic/Observer.java
+++ b/src/main/java/seedu/address/logic/Observer.java
@@ -3,5 +3,5 @@ package seedu.address.logic;
 import seedu.address.logic.commands.exceptions.CommandException;
 
 public interface Observer {
-    void update() throws CommandException;
+    void update(String input);
 }

--- a/src/main/java/seedu/address/logic/Observer.java
+++ b/src/main/java/seedu/address/logic/Observer.java
@@ -1,7 +1,5 @@
 package seedu.address.logic;
 
-import seedu.address.logic.commands.exceptions.CommandException;
-
 public interface Observer {
     void update(String input);
 }

--- a/src/main/java/seedu/address/logic/StatisticsManager.java
+++ b/src/main/java/seedu/address/logic/StatisticsManager.java
@@ -21,9 +21,7 @@ public class StatisticsManager {
         this.statistics = statistics;
     }
 
-    /**
-     * Update StatisticsDisplay fields for user output.
-     */
+    /** Update StatisticsDisplay fields for user output. */
     public void updateStatisticsDisplayValues() {
         ObservableList<DayData> dayDatas = statistics.getCustomQueue();
         requireNonNull(statistics);
@@ -50,8 +48,7 @@ public class StatisticsManager {
             expBarPerc = 100;
         }
 
-        progressBarDailyFilepathString =
-                "/images/progress/ProgressBar" + expBarPerc + "%.png";
+        progressBarDailyFilepathString = "/images/progress/ProgressBar" + expBarPerc + "%.png";
     }
 
     public void setDailyTargetText(String dailyTargetText) {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -64,7 +64,6 @@ public class AddCommand extends Command {
         }
 
         model.addTask(toAdd);
-        // toAdd.triggerRecurringIfPresent(model, indexOfNewTask);
         // ^ Sample use of model to adjust objects
         // model.setPetName("Jeff");
         // model.setPomodoroTask(toAdd);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -110,11 +110,11 @@ public interface Model {
     ObservableList<DayData> getCustomQueue();
 
     /**
-     * Notifies observers when a change is made. Observer in this case is the logic manager.
+     * Notifies observers when a change is made. Observer in this case is the MainWindow.
      *
      * @throws CommandException
      */
-    void notifyObservers() throws CommandException;
+    void notifyMainWindow(String input) throws CommandException;
 
     void addObserver(Observer observer);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -20,12 +20,10 @@ import seedu.address.logic.Observer;
 import seedu.address.logic.PetManager;
 import seedu.address.logic.PomodoroManager;
 import seedu.address.logic.StatisticsManager;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.dayData.DayData;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
 import seedu.address.model.task.Recurring;
 import seedu.address.model.task.Task;
-import seedu.address.ui.MainWindow;
 
 /** Represents the in-memory model of the task list data. */
 public class ModelManager implements Model {
@@ -150,7 +148,8 @@ public class ModelManager implements Model {
                             if (Recurring.shouldUpdateTask(t)) {
                                 Task recurredTask = t.getRecurredTask();
                                 setTask(t, recurredTask);
-                                String recurredString = "Recurring task has been reset: " + recurredTask.toString();
+                                String recurredString =
+                                        "Recurring task has been reset: " + recurredTask.toString();
                                 notifyMainWindow(recurredString);
                             }
                         });
@@ -224,7 +223,7 @@ public class ModelManager implements Model {
 
     // =========== Subject Methods for Observer
     // ================================================================================
-    public void notifyMainWindow(String input){
+    public void notifyMainWindow(String input) {
         for (Observer observer : observers) {
             observer.update(input);
         }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -20,7 +20,6 @@ import seedu.address.logic.Observer;
 import seedu.address.logic.PetManager;
 import seedu.address.logic.PomodoroManager;
 import seedu.address.logic.StatisticsManager;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.dayData.Date;
 import seedu.address.model.dayData.DayData;
 import seedu.address.model.task.NameContainsKeywordsPredicate;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,7 +23,9 @@ import seedu.address.logic.StatisticsManager;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.dayData.DayData;
 import seedu.address.model.task.NameContainsKeywordsPredicate;
+import seedu.address.model.task.Recurring;
 import seedu.address.model.task.Task;
+import seedu.address.ui.MainWindow;
 
 /** Represents the in-memory model of the task list data. */
 public class ModelManager implements Model {
@@ -129,10 +131,12 @@ public class ModelManager implements Model {
         this.recurringTimerTasks.clear();
         for (Task t : this.taskList.getTaskList()) {
             if (t.getOptionalRecurring().isPresent()) {
-                TimerTask tt = this.generateTimerTask(t);
-                recurringTimerTasks.put(t, tt);
-                this.recurringTimer.scheduleAtFixedRate(
-                        tt, t.getDelayToFirstTrigger(), t.getRecurPeriod());
+                if (Recurring.shouldUpdateTask(t)) {
+                    TimerTask tt = this.generateTimerTask(t);
+                    recurringTimerTasks.put(t, tt);
+                    this.recurringTimer.scheduleAtFixedRate(
+                            tt, t.getDelayToFirstTrigger(), t.getRecurPeriod());
+                }
             }
         }
     }
@@ -143,7 +147,12 @@ public class ModelManager implements Model {
             public void run() {
                 Platform.runLater(
                         () -> {
-                            setTask(t, t.getRecurredTask());
+                            if (Recurring.shouldUpdateTask(t)) {
+                                Task recurredTask = t.getRecurredTask();
+                                setTask(t, recurredTask);
+                                String recurredString = "Recurring task has been reset: " + recurredTask.toString();
+                                notifyMainWindow(recurredString);
+                            }
                         });
             }
         };
@@ -215,9 +224,9 @@ public class ModelManager implements Model {
 
     // =========== Subject Methods for Observer
     // ================================================================================
-    public void notifyObservers() throws CommandException {
+    public void notifyMainWindow(String input){
         for (Observer observer : observers) {
-            observer.update();
+            observer.update(input);
         }
     }
 

--- a/src/main/java/seedu/address/model/task/Recurring.java
+++ b/src/main/java/seedu/address/model/task/Recurring.java
@@ -3,6 +3,8 @@ package seedu.address.model.task;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -45,10 +47,22 @@ public class Recurring {
         }
     }
 
-    public boolean shouldUpdateReminder(LocalDateTime reminderDateTime) {
+    public static boolean shouldUpdateReminder(LocalDateTime reminderDateTime) {
         Duration duration = Duration.between(LocalDateTime.now(), reminderDateTime);
         boolean hasPassed = duration.getSeconds() < 0;
         return hasPassed;
+    }
+
+    /** Returns boolean on whether the task should be updated or not */
+    public static boolean shouldUpdateTask(Task t) {
+        boolean isDone = t.getDone().getIsDone();
+        Optional<Reminder> optReminder = t.getOptionalReminder();
+        boolean updateReminder = false;
+        if (optReminder.isPresent()) {
+            LocalDateTime reminderDateTime = optReminder.get().getDateTime();
+            updateReminder = shouldUpdateReminder(reminderDateTime);
+        }
+        return isDone || updateReminder;
     }
 
     public LocalDateTime getUpdatedReminderTime(Reminder currentReminder) {

--- a/src/main/java/seedu/address/model/task/Recurring.java
+++ b/src/main/java/seedu/address/model/task/Recurring.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
-
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -48,7 +48,6 @@ import seedu.address.model.settings.DailyTarget;
 import seedu.address.model.settings.PetName;
 import seedu.address.model.settings.PomDuration;
 import seedu.address.model.task.Reminder;
-import seedu.address.logic.Observer;
 
 /**
  * The Main Window. Provides the basic application layout containing a menu bar and space where
@@ -512,6 +511,4 @@ public class MainWindow extends UiPart<Stage> {
         alert.setContentText(description);
         alert.show();
     }
-
-    
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -13,7 +13,6 @@ import java.util.TimerTask;
 import java.util.logging.Logger;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
-import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -48,6 +48,7 @@ import seedu.address.model.settings.DailyTarget;
 import seedu.address.model.settings.PetName;
 import seedu.address.model.settings.PomDuration;
 import seedu.address.model.task.Reminder;
+import seedu.address.logic.Observer;
 
 /**
  * The Main Window. Provides the basic application layout containing a menu bar and space where
@@ -395,6 +396,10 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    public void displayRecurring(String recurringFeedback) {
+        resultDisplay.setFeedbackToUser(recurringFeedback);
+    }
+
     public void setPomCommandExecutor() {
         commandBox = new CommandBox(this::pomExecuteCommand, this::suggestCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
@@ -507,4 +512,6 @@ public class MainWindow extends UiPart<Stage> {
         alert.setContentText(description);
         alert.show();
     }
+
+    
 }

--- a/src/main/java/seedu/address/ui/Ui.java
+++ b/src/main/java/seedu/address/ui/Ui.java
@@ -1,9 +1,10 @@
 package seedu.address.ui;
 
 import javafx.stage.Stage;
+import seedu.address.logic.Observer;
 
 /** API of UI component */
-public interface Ui {
+public interface Ui extends Observer {
 
     /** Starts the UI (and the App). */
     void start(Stage primaryStage);

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -10,6 +10,7 @@ import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
+import seedu.address.logic.Observer;
 import seedu.address.logic.PetManager;
 import seedu.address.logic.PomodoroManager;
 import seedu.address.logic.StatisticsManager;
@@ -94,4 +95,10 @@ public class UiManager implements Ui {
         Platform.exit();
         System.exit(1);
     }
+
+    @Override
+    public void update(String input) {
+        mainWindow.displayRecurring(input);
+    }
+
 }

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -10,7 +10,6 @@ import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
-import seedu.address.logic.Observer;
 import seedu.address.logic.PetManager;
 import seedu.address.logic.PomodoroManager;
 import seedu.address.logic.StatisticsManager;
@@ -100,5 +99,4 @@ public class UiManager implements Ui {
     public void update(String input) {
         mainWindow.displayRecurring(input);
     }
-
 }

--- a/src/test/java/seedu/address/logic/PomodoroManagerTest.java
+++ b/src/test/java/seedu/address/logic/PomodoroManagerTest.java
@@ -93,7 +93,8 @@ public class PomodoroManagerTest {
         LocalDateTime end = LocalDateTime.now();
         LocalDateTime start = end.minusMinutes(AMOUNT_TO_TEST);
         DayData d =
-                model.getDayDataFromDateStatistics(new Date(LocalDateTime.now().toLocalDate().toString()));
+                model.getDayDataFromDateStatistics(
+                        new Date(LocalDateTime.now().toLocalDate().toString()));
         assertTrue(d.getPomDurationData().value == 0);
         pomodoroManager.setStartDateTime(start);
         pomodoroManager.updateStatistics(model);

--- a/src/test/java/seedu/address/logic/StatisticsManagerTest.java
+++ b/src/test/java/seedu/address/logic/StatisticsManagerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.model.Statistics.DEFAULT_DAILY_TARGET;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalDayDatas.DAY6;
-import static seedu.address.testutil.TypicalDayDatas.getTypicalDayDatas;
 import static seedu.address.testutil.TypicalDayDatas.getTypicalStatistics;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -225,7 +225,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updatesDayDataStatistics(DayData dayData)  {
+        public void updatesDayDataStatistics(DayData dayData) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -264,7 +264,6 @@ public class AddCommandTest {
         @Override
         public void notifyMainWindow(String inputString) throws CommandException {
             throw new AssertionError("This method should not be called.");
-
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -256,7 +256,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void notifyObservers() throws CommandException {
+        public void notifyMainWindow(String inputString) throws CommandException {
             // TODO Auto-generated method stub
 
         }

--- a/src/test/java/seedu/address/logic/commands/SetCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SetCommandTest.java
@@ -1,14 +1,8 @@
 package seedu.address.logic.commands;
 
-import seedu.address.model.Model;
-import seedu.address.model.Pet;
-import seedu.address.model.Pomodoro;
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.function.Predicate;
 import javafx.collections.ObservableList;
@@ -20,17 +14,16 @@ import seedu.address.logic.PomodoroManager;
 import seedu.address.logic.StatisticsManager;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.Pet;
+import seedu.address.model.Pomodoro;
 import seedu.address.model.ReadOnlyPet;
 import seedu.address.model.ReadOnlyPomodoro;
 import seedu.address.model.ReadOnlyTaskList;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.Statistics;
-import seedu.address.model.TaskList;
 import seedu.address.model.dayData.Date;
 import seedu.address.model.dayData.DayData;
 import seedu.address.model.task.Task;
-import seedu.address.testutil.TaskBuilder;
-
 
 public class SetCommandTest {
 
@@ -48,8 +41,8 @@ public class SetCommandTest {
         ModelStubWithPomodoro modelStub = new ModelStubWithPomodoro(pomodoro);
         modelStub.setPomodoroDefaultTime(5);
         assertTrue(pomodoro.getDefaultTime().equals("5.0"));
-        
     }
+
     private class ModelStub implements Model {
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -190,7 +183,7 @@ public class SetCommandTest {
         public void updatesDayDataStatistics(DayData dayData) {
             throw new AssertionError("This method should not be called.");
         }
-        
+
         @Override
         public DayData getDayDataFromDateStatistics(Date date) {
             throw new AssertionError("This method should not be called.");
@@ -214,7 +207,6 @@ public class SetCommandTest {
         @Override
         public void setPomodoroTimeLeft(float timeLeft) {
             throw new AssertionError("This method should not be called.");
-
         }
 
         @Override
@@ -234,7 +226,7 @@ public class SetCommandTest {
     }
 
     private class ModelStubWithPomodoro extends ModelStub {
-        final private Pomodoro pomodoro;
+        private final Pomodoro pomodoro;
 
         ModelStubWithPomodoro(Pomodoro pomodoro) {
             this.pomodoro = pomodoro;
@@ -247,7 +239,7 @@ public class SetCommandTest {
     }
 
     private class ModelStubWithPet extends ModelStub {
-        final private Pet pet;
+        private final Pet pet;
 
         ModelStubWithPet(Pet pet) {
             this.pet = pet;

--- a/src/test/java/seedu/address/logic/parser/SetCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SetCommandParserTest.java
@@ -1,18 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PET;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_POM;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DAILY;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-
-import org.junit.jupiter.api.Test;
-
-import seedu.address.logic.commands.SetCommand;
-import seedu.address.model.settings.DailyTarget;
-import seedu.address.model.settings.PetName;
-import seedu.address.model.settings.PomDuration;
-
 public class SetCommandParserTest {
     // private SetCommandParser parser = new SetCommandParser();
 
@@ -23,8 +10,10 @@ public class SetCommandParserTest {
     // @Test
     // public void parse_allFieldsPresent_success() {
     //     SetCommandParser parser = new SetCommandParser();
-    //     // SetCommand expectedSetCommand = new SetCommand(new PetName(VALID_PETNAME) ,   new PomDuration(VALID_POM) , new DailyTarget(VALID_DAILY));
-    //     SetCommand expectedSetCommand = new SetCommand(new PetName(VALID_PETNAME), new PomDuration(""), new DailyTarget(""));
+    //     // SetCommand expectedSetCommand = new SetCommand(new PetName(VALID_PETNAME) ,   new
+    // PomDuration(VALID_POM) , new DailyTarget(VALID_DAILY));
+    //     SetCommand expectedSetCommand = new SetCommand(new PetName(VALID_PETNAME), new
+    // PomDuration(""), new DailyTarget(""));
 
     //     assertParseSuccess(
     //         parser,


### PR DESCRIPTION
Adapted the observer pattern to update the result display whenever a recurring task is reset.

Manual Testing instructions:
- add a task with rec/d 
- done that task
- recurring behaviour: 1 minute later it should be marked as undone
- add a reminder (1 minute later than your current time) to that task 
- recurring behaviour: after the reminder is triggered, 1 minute later the reminder's date increments by 1 day
- if task is not done or the reminder has not been triggered yet, no recurring behaviour should show on the result display


- on recurring behaviour result display should say "Recurring task has been reset: " and the task's toString()